### PR TITLE
Kan 10 add 3 cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,53 +22,60 @@ curl -X POST https://blue-wave-0b3a88b03.6.azurestaticapps.net/api/classifypengu
   -d '{"features": [47.5, 15.0, 21.7, 50.76]}'
 ```
 
-## 🎯 **Project Overview**
+## 🎯 **What This Project Does**
 
 ### **Purpose**
-This project demonstrates end-to-end machine learning deployment using Azure cloud services. It predicts penguin species (Adelie, Chinstrap, or Gentoo) based on four physical measurements.
+This project demonstrates end-to-end machine learning deployment using Azure cloud services. It classifies penguin species (Adelie, Chinstrap, or Gentoo) based on four physical measurements using a production-ready web application.
 
-### **Goals**
-- **Educational**: Showcase modern ML deployment practices
-- **Technical**: Demonstrate Azure Functions, Static Web Apps, and ML integration
-- **Portfolio**: Exhibit cloud development and machine learning skills
+### **Key Features**
+- **Real-time ML Predictions**: Instant species classification from penguin measurements
+- **Cloud-Native Architecture**: Fully serverless deployment on Azure platform
+- **Interactive Web Interface**: User-friendly form with immediate results display
+- **Enterprise-Grade API**: RESTful endpoint for programmatic access
 
-### **Scope**
-- **Input**: Culmen length, culmen depth, flipper length, body mass
-- **Output**: Species classification with confidence score
-- **Technology Stack**: Python, scikit-learn, Azure Functions, Azure Static Web Apps
-- **Response Time**: <1 second
-- **Cost**: ~$0.001 per prediction
+### **Input & Output**
+- **Input**: Culmen length, culmen depth, flipper length, body mass (in mm/grams)
+- **Output**: Species classification with confidence score and explainable AI insights
+- **Performance**: <1 second response time, ~$0.001 per prediction
 
-## 🏗️ **Architecture**
+## 🏗️ **How It Works - Technical Implementation**
 
-### **System Overview**
+### **System Architecture & Data Flow**
 ```
-┌─────────────────┐    ┌──────────────────┐    ┌─────────────┐
-│   Web Browser   │ ── │ Azure Function   │ ── │ Prediction  │
-│  (Static App)   │    │ (Python 3.10)    │    │  Response   │
-└─────────────────┘    └──────────────────┘    └─────────────┘
+User Input → Frontend Validation → HTTP Request → Azure Function → Pre-trained ML Model → JSON Response → Web Display
 ```
 
-**Components:**
+### **Step-by-Step Process**
+1. **User Interaction**: User enters penguin measurements via web interface
+2. **Data Processing**: JavaScript validates and normalizes input data 
+3. **HTTP Trigger**: POST request sent to Azure Function endpoint (`/api/classifypenguinsimple`)
+4. **Model Inference**: Pre-trained Random Forest classifier processes the features
+5. **Response Generation**: Function returns JSON with species prediction and confidence
+6. **Result Display**: Web interface updates with classification results and explanations
+
+### **Core Components**
 1. **Frontend**: Azure Static Web App (HTML/CSS/JavaScript)
-2. **Backend**: Azure Functions (Python + ML Model)
-3. **Model**: Random Forest Classifier (scikit-learn)
+   - Responsive web interface for data input
+   - Real-time form validation and user feedback
+   - Interactive results display with explainable AI features
 
-**Why This Architecture:**
-- **Cost Effective**: ~$0.001 per prediction vs traditional servers
-- **Fast Response**: <1 second prediction time
-- **Auto-Scaling**: Handles traffic spikes automatically
-- **Serverless**: No infrastructure management required
+2. **Backend**: Azure Functions (Python 3.10)
+   - HTTP-triggered serverless function
+   - Cached pre-trained scikit-learn Random Forest model
+   - JSON API with CORS support for cross-origin requests
 
-## 📊 **Machine Learning Model**
+3. **Machine Learning**: Random Forest Classifier
+   - Pre-trained on Palmer Penguins dataset (>97% accuracy)
+   - Cached in memory for fast inference (<100ms)
+   - Handles 4 normalized features: culmen dimensions, flipper length, body mass
 
-- **Algorithm**: Random Forest Classifier
-- **Accuracy**: >97% on test dataset
-- **Input**: 4 penguin measurements (culmen, flipper, body mass)
-- **Output**: Species classification (Adelie, Chinstrap, or Gentoo) with confidence score
-- **Training Data**: Palmer Penguins dataset from Antarctica research stations
+### **Technical Flow Details**
+- **Model Loading**: Random Forest classifier loaded once and cached globally
+- **Feature Processing**: Input normalized to match training data scaling
+- **Prediction Pipeline**: Model inference → probability calculation → species mapping
+- **Response Format**: Structured JSON with prediction, confidence, and metadata
 
-## 🚀 **Deployment**
+## 🚀 **Live Deployment & Access**
 
 ### **Live Application**
 - **Web Interface**: https://blue-wave-0b3a88b03.6.azurestaticapps.net/
@@ -160,14 +167,37 @@ For detailed technical implementation, see **[Technical Documentation](documenta
 ### **Additional Documentation**
 - **[Technical Overview](documentation/TECHNICAL_OVERVIEW.md)** - Complete system architecture, API reference, and implementation details for academic/professional presentations
 
-### **Learning Outcomes**
+## 🎯 **Why This Project Matters - Showcase Objectives**
 
-This project demonstrates:
-- **Cloud Architecture**: Serverless computing with Azure Functions
-- **Machine Learning Deployment**: Production ML model serving
-- **Web Development**: Modern JavaScript and responsive design
-- **DevOps**: CI/CD with GitHub and Azure integration
-- **Cost Optimization**: Choosing appropriate cloud services for workload
+### **Cloud Infrastructure Demonstration**
+This project showcases modern cloud-native architecture patterns:
+- **Serverless Computing**: Azure Functions eliminate infrastructure management overhead
+- **Static Web Apps**: Cost-effective frontend hosting with integrated CI/CD
+- **Auto-Scaling**: Platform handles traffic spikes automatically without configuration
+- **Pay-per-Use Model**: Only pay for actual function executions (~$0.001 per prediction)
+
+### **Machine Learning Best Practices**
+Demonstrates production ML deployment techniques:
+- **Model Serving**: Efficient in-memory caching of pre-trained models
+- **API Design**: RESTful endpoints with proper error handling and validation
+- **Performance Optimization**: <1 second response times with cold start management
+- **Explainable AI**: Feature importance and confidence scoring for transparency
+
+### **Azure Platform Integration**
+Exhibits comprehensive Azure ecosystem usage:
+- **Azure Static Web Apps**: Seamless frontend deployment with GitHub integration
+- **Azure Functions**: Serverless compute for ML inference workloads
+- **Application Insights**: Built-in monitoring and performance analytics
+- **DevOps Integration**: Automated deployment pipelines via GitHub Actions
+
+### **End-to-End Solution Architecture**
+Showcases complete cloud solution development:
+- **Full-Stack Development**: Frontend, backend, and ML model integration
+- **Production Readiness**: Error handling, CORS configuration, and scalability
+- **Cost Optimization**: Choosing appropriate Azure services for workload requirements
+- **Developer Experience**: Local development workflow with cloud deployment automation
+
+This project serves as a practical example of how to leverage Azure's cloud infrastructure to deploy machine learning models in a production-ready, cost-effective, and scalable manner.
 
 ## 🤝 **Contributing**
 


### PR DESCRIPTION
While the changes to the readme.md were good, what I wanted was to implement 3 cards on the actual webpage. The 3 cards could be clicked, or tapped on mobile and they would do this:
“what” - what is the purpose of the project - very similar to the stuff already in the readme.md

“how” - explain how it achieves that - attaching a pre-trained random forest classifier scikit-learn model to an Azure function. the function is triggered via HTTP request, and once the model generates an output, it is displayed to the user via the web interface.

“why” - showcase the use of cloud infrastructure, machine learning practices, and using the azure platform to integrate this into an end-to-end solution.
The goal of these 3 cards is to inform the webpage visitors, giving them more information on this project. While the readme.md is for someone who looks at the repository, these cards will inform users of the webpage. However, the description of the cards must be informative, but concise, to not overwhelm the user. When the cards are clicked, they should expand with the corresponding information. If they are clicked again, they should colapse in the original form.